### PR TITLE
implement V6 analyzer recommendations to eliminate annoying warning msgs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,295 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = false
+file_header_template = unset
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary
+dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_style_prefer_foreach_explicit_cast_in_source = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
+
+# Field preferences
+dotnet_style_readonly_field = true
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = false
+dotnet_style_allow_statement_immediately_after_block_experimental = true
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:suggestion
+csharp_style_expression_bodied_constructors = true:suggestion
+csharp_style_expression_bodied_indexers = true:suggestion
+csharp_style_expression_bodied_lambdas = true:suggestion
+csharp_style_expression_bodied_local_functions = true:suggestion
+csharp_style_expression_bodied_methods = true:suggestion
+csharp_style_expression_bodied_operators = true:suggestion
+csharp_style_expression_bodied_properties = true:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = false:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,file,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,required,volatile,async
+
+# Code-block preferences
+csharp_prefer_braces = true:silent
+csharp_prefer_simple_using_statement = false:suggestion
+csharp_style_namespace_declarations = file_scoped:suggestion
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:silent
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:suggestion
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = false:silent
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = one_less_than_current
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+dotnet_diagnostic.CA1001.severity=suggestion
+dotnet_diagnostic.CA1309.severity=suggestion
+dotnet_diagnostic.CA1805.severity=suggestion
+dotnet_diagnostic.RCS1005.severity=suggestion
+dotnet_diagnostic.RCS1006.severity=suggestion
+dotnet_diagnostic.RCS1008.severity= silent
+dotnet_diagnostic.RCS1010.severity=suggestion
+dotnet_diagnostic.RCS1018.severity = silent
+dotnet_diagnostic.RCS1031.severity=suggestion
+dotnet_diagnostic.RCS1035.severity=suggestion
+dotnet_diagnostic.RCS1040.severity=suggestion
+dotnet_diagnostic.RCS1061.severity=suggestion
+dotnet_diagnostic.RCS1066.severity=suggestion
+dotnet_diagnostic.RCS1069.severity=suggestion
+dotnet_diagnostic.RCS1070.severity=suggestion
+dotnet_diagnostic.RCS1071.severity=suggestion
+dotnet_diagnostic.RCS1074.severity=suggestion
+dotnet_diagnostic.RCS1124.severity=suggestion
+dotnet_diagnostic.RCS1129.severity=suggestion
+dotnet_diagnostic.RCS1134.severity=suggestion
+dotnet_diagnostic.RCS1136.severity=suggestion
+dotnet_diagnostic.RCS1143.severity=suggestion
+dotnet_diagnostic.RCS1145.severity=suggestion
+dotnet_diagnostic.RCS1151.severity=suggestion
+dotnet_diagnostic.RCS1168.severity=suggestion
+dotnet_diagnostic.RCS1177.severity=suggestion
+dotnet_diagnostic.RCS1188.severity=suggestion
+dotnet_diagnostic.RCS1189.severity=suggestion
+dotnet_diagnostic.RCS1211.severity=suggestion
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_utf8_string_literals = true:suggestion
+
+[*.{cs,vb}]
+dotnet_style_require_accessibility_modifiers=omit_if_default:silent
+dotnet_diagnostic.CA1310.severity=suggestion
+dotnet_diagnostic.CA1708.severity=suggestion
+dotnet_diagnostic.CA1716.severity=suggestion
+dotnet_diagnostic.CA1725.severity=suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:warning
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_readonly_field = true:suggestion
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
+dotnet_style_allow_multiple_blank_lines_experimental = false:silent
+dotnet_code_quality_unused_parameters = all:suggestion
+dotnet_style_parentheses_in_arithmetic_binary_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_other_binary_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent

--- a/EntityFrameworkNet5.ConsoleApp/Program.cs
+++ b/EntityFrameworkNet5.ConsoleApp/Program.cs
@@ -1,466 +1,448 @@
 ﻿using EntityFrameworkNet5.Data;
 using EntityFrameworkNet5.Domain;
-using EntityFrameworkNet5.Domain.Models;
-using Microsoft.EntityFrameworkCore;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 
-namespace EntityFrameworkNet5.ConsoleApp
+FootballLeageDbContext context = new();
+
+/* Simple Insert Operation Methods */
+await AddNewLeague();
+await AddNewLeagueTransaction();
+await AddNewLeagueTransactionWithRollback();
+////await AddNewTeamsWithLeague();
+
+/* Simple Select Queries */
+////await SimpleSelectQuery();
+
+/* Queries With Filters */
+////await QueryFilters();
+
+/* Aggregate Functions */
+////await AdditionalExecutionMethods();
+
+/*Alternative LINQ Syntax*/
+////await AlternativeLinqSyntax();
+
+/* Perform Update */
+////await SimpleUpdateLeagueRecord();
+////await SimpleUpdateTeamRecord();
+
+/* Perform Delete */
+////await SimpleDelete();
+////await DeleteWithRelationship();
+
+/*Tracking vs No-Tracking*/
+////await TrackingVsNoTracking();
+
+/*Adding Records with relationships*/
+////Adding OneToMany Related Records
+////await AddNewTeamsWithLeague();
+////await AddNewTeamWithLeagueId();
+////await AddNewLeagueWithTeams();
+
+////Adding ManyToMany Records
+////await AddNewMatches();
+
+////Adding OneToOne Records
+////await AddNewCoach();
+
+/* Including Related Data - Eager Loading*/
+////await QueryRelatedRecords();
+
+/* Projections to Other Data Types or Ananymous Types */
+////await SelectOneProperty();
+////await AnonymousProjection();
+////await StronglyTypedProjection();
+
+/* Filter Based on Related Data */
+////await FilteringWithRelatedData();
+
+/* Querying Views */
+////await QueryView();
+
+/* Query With Raw SQL */
+////await RawSQLQuery();
+
+/* Query Stored Procedures */
+////await ExecStoredProcedure();
+
+/* RAW SQL Non-Query Commands */
+////await ExecuteNonQueryCommand();
+
+Console.WriteLine("Press Any Key To End....");
+Console.ReadKey();
+
+////async static Task ExecuteNonQueryCommand()
+////{
+////    var teamId = 10;
+////    var affectedRows = await context.Database.ExecuteSqlRawAsync("exec sp_DeleteTeamById {0}", teamId);
+
+////    var teamId2 = 12;
+////    var affectedRows2 = await context.Database.ExecuteSqlInterpolatedAsync($"exec sp_DeleteTeamById {teamId2}");
+////}
+
+////async static Task ExecStoredProcedure()
+////{
+////    var teamId = 3;
+////    var result = await context.Coaches.FromSqlRaw("EXEC dbo.sp_GetTeamCoach {0}", teamId).ToListAsync();
+////}
+
+////async static Task RawSQLQuery()
+////{
+////    var name = "AS Roma";
+////    var teams1 = await context.Teams.FromSqlRaw($"Select * from Teams where name = '{name}'")
+////        .Include(q => q.Coach).ToListAsync();
+
+////    var teams2 = await context.Teams.FromSqlInterpolated($"Select * from Teams where name = {name}").ToListAsync();
+
+////}
+
+////async static Task QueryView()
+////{
+////    var details = await context.TeamsCoachesLeagues.ToListAsync();
+////}
+
+////async static Task FilteringWithRelatedData()
+////{
+////    var leagues = await context.Leagues.Where(q => q.Teams.Any(x => x.Name.Contains("Bay"))).ToListAsync();
+////}
+
+////async static Task SelectOneProperty()
+////{
+////    var teams = await context.Teams.Select(q => q.Name).ToListAsync();
+////}
+
+////async static Task AnonymousProjection()
+////{
+////    var teams = await context.Teams.Include(q => q.Coach).Select(
+////        q => 
+////        new { 
+////                TeamName = q.Name, 
+////                CoachName = q.Coach.Name
+////            }
+////        ).ToListAsync();
+
+////    foreach (var item in teams)
+////    {
+////        Console.WriteLine($"Team: {item.TeamName} | Coach: {item.CoachName}");
+////    }
+////}
+
+////async static Task StronglyTypedProjection()
+////{
+////    var teams = await context.Teams.Include(q => q.Coach).Include(q => q.League).Select(
+////        q =>
+////        new TeamsCoachesLeaguesView {
+////            Name = q.Name,
+////            CoachName = q.Coach.Name,
+////            LeagueName = q.League.Name
+////        }
+////        ).ToListAsync();
+////    foreach (var item in teams)
+////    {
+////        Console.WriteLine($"Team: {item.Name} | Coach: {item.CoachName} | League: {item.LeagueName}");
+////    }
+////}
+
+////static async Task QueryRelatedRecords()
+////{
+////    //// Get Many Related Records - Leagues -> Teams
+////    var leagues = await context.Leagues.Include(q => q.Teams).ToListAsync();
+
+////    //// Get One Related Record - Team -> Coach
+////    var team = await context.Teams
+////        .Include(q => q.Coach)
+////        .FirstOrDefaultAsync(q => q.Id == 3);
+
+////    //// Get 'Grand Children' Related Record - Team -> Matches -> Home/Away Team
+////    var teamsWithMatchesAndOpponents = await context.Teams
+////        .Include(q => q.AwayMatches).ThenInclude(q => q.HomeTeam).ThenInclude(q => q.Coach)
+////        .Include(q => q.HomeMatches).ThenInclude(q => q.AwayTeam).ThenInclude(q => q.Coach)
+////        .FirstOrDefaultAsync(q => q.Id == 1);
+
+////    //// Get Includes with filters
+////    var teams = await context.Teams
+////        .Where(q => q.HomeMatches.Count > 0)
+////        .Include(q => q.Coach)
+////        .ToListAsync(); 
+////}
+
+////private static async Task TrackingVsNoTracking()
+////{
+////    var withTracking = await context.Teams.FirstOrDefaultAsync(q => q.Id == 2);
+////    var withNoTracking = await context.Teams.AsNoTracking().FirstOrDefaultAsync(q => q.Id == 8);
+
+////    withTracking.Name = "Inter Milan";
+////    withNoTracking.Name = "Rivoli United";
+
+////    var entriesBeforeSave = context.ChangeTracker.Entries();
+
+////    await context.SaveChangesAsync();
+
+////    var entriesAfterSave = context.ChangeTracker.Entries();
+////}
+
+////private static async Task SimpleDelete()
+////{
+////    var league = await context.Leagues.FindAsync(4);
+////    context.Leagues.Remove(league);
+////    await context.SaveChangesAsync();
+////}
+
+////private static async Task DeleteWithRelationship()
+////{
+////    var league = await context.Leagues.FindAsync(9);
+////    context.Leagues.Remove(league);
+////    await context.SaveChangesAsync();
+////}
+
+////private static async Task SimpleUpdateTeamRecord()
+////{
+////    var team = new Team
+////    {
+////        Id = 7,
+////        Name = "Seba United FC",
+////        LeagueId = 2
+////    };
+////    context.Teams.Update(team);
+////    await context.SaveChangesAsync("Test Update User");
+////}
+
+////private static async Task GetRecord()
+////{
+////    ////Retrieve Record
+////    var league = await context.Leagues.FindAsync(3);
+////    Console.WriteLine($"{league.Id} - {league.Name}");
+////}
+
+////private static async Task SimpleUpdateLeagueRecord()
+////{
+////    ////Retrieve Record
+////    var league = await context.Leagues.FindAsync(20);
+////    ///Make Record Changes
+////    league.Name = "Scottish Premiership";
+////    ///Save Changes
+////    await context.SaveChangesAsync();
+
+////    await GetRecord();
+
+////}
+
+////static async Task AlternativeLinqSyntax()
+////{
+////    Console.Write($"Enter Team Name (Or Part Of): ");
+////    var teamName = Console.ReadLine();
+////    var teams = await (from i in context.Teams
+////                       where EF.Functions.Like(i.Name, $"%{teamName}%")
+////                       select i).ToListAsync();
+
+////    foreach (var team in teams)
+////    {
+////        Console.WriteLine($"{team.Id} - {team.Name}");
+////    }
+////}
+
+////static async Task AdditionalExecutionMethods()
+////{
+////    //// These methods also have non-async
+////    var leagues = context.Leagues;
+////    var list = await leagues.ToListAsync();
+////    var first = await leagues.FirstAsync();
+////    var firstOrDefault = await leagues.FirstOrDefaultAsync();
+////    var single = await leagues.SingleAsync();
+////    var singleOrDefault = await leagues.SingleOrDefaultAsync();
+
+////    var count = await leagues.CountAsync();
+////    var longCount = await leagues.LongCountAsync();
+////    var min = await leagues.MinAsync();
+////    var max = await leagues.MaxAsync();
+
+////    //// DbSet Method that will execute
+////    var league = await leagues.FindAsync(1);
+
+////}
+
+////static async Task QueryFilters()
+////{
+////    Console.Write($"Enter League Name (Or Part Of): ");
+////    var leagueName = Console.ReadLine();
+////    var exactMatches= await context.Leagues.Where(q => q.Name.Equals(leagueName)).ToListAsync();
+////    foreach (var league in exactMatches)
+////    {
+////        Console.WriteLine($"{league.Id} - {league.Name}");
+////    }
+
+////    ////var partialMatches = await context.Leagues.Where(q => q.Name.Contains(leagueName)).ToListAsync();
+////    var partialMatches = await context.Leagues.Where(q => EF.Functions.Like(q.Name, $"%{leagueName}%")).ToListAsync();
+////    foreach (var league in partialMatches)
+////    {
+////        Console.WriteLine($"{league.Id} - {league.Name}");
+////    }
+////}
+
+////static async Task SimpleSelectQuery()
+////{
+////    //// Smartest most efficient way to get results
+////    var leagues = await context.Leagues.ToListAsync();
+////    foreach (var league in leagues)
+////    {
+////        Console.WriteLine($"{league.Id} - {league.Name}");
+////    }
+
+////    //// Inefficient way to get results. Keeps connection open until completed and might create lock on table
+////    ////foreach (var league in context.Leagues)
+////    ////{
+////    ////    Console.WriteLine($"{league.Id} - {league.Name}");
+////    ////}
+
+////}
+
+async Task AddNewLeague()
 {
-    class Program
+    //// Adding a new League Object
+    var league = new League { Name = "Audit Testing League" };
+    await context.Leagues.AddAsync(league);
+    await context.SaveChangesAsync("Test Audit Create User");
+
+    //// Function To add new teams related to the new league object. 
+    await AddTeamsWithLeague(league);
+    await context.SaveChangesAsync();
+}
+
+async Task AddNewLeagueTransaction()
+{
+    var transaction = context.Database.BeginTransaction();
+
+    try
     {
-        private static FootballLeageDbContext context = new FootballLeageDbContext();
-
-        static async Task Main(string[] args)
-        {
-            /* Simple Insert Operation Methods */
-            await AddNewLeague();
-            await AddNewLeagueTransaction();
-            await AddNewLeagueTransactionWithRollback();
-            ////await AddNewTeamsWithLeague();
-
-            /* Simple Select Queries */
-            ////await SimpleSelectQuery();
-
-            /* Queries With Filters */
-            ////await QueryFilters();
-
-            /* Aggregate Functions */
-            ////await AdditionalExecutionMethods();
-
-            /*Alternative LINQ Syntax*/
-            ////await AlternativeLinqSyntax();
-
-            /* Perform Update */
-            ////await SimpleUpdateLeagueRecord();
-            ////await SimpleUpdateTeamRecord();
-
-            /* Perform Delete */
-            ////await SimpleDelete();
-            ////await DeleteWithRelationship();
-
-            /*Tracking vs No-Tracking*/
-            ////await TrackingVsNoTracking();
-
-            /*Adding Records with relationships*/
-            ////Adding OneToMany Related Records
-            ////await AddNewTeamsWithLeague();
-            ////await AddNewTeamWithLeagueId();
-            ////await AddNewLeagueWithTeams();
-
-            ////Adding ManyToMany Records
-            ////await AddNewMatches();
-
-            ////Adding OneToOne Records
-            ////await AddNewCoach();
-
-            /* Including Related Data - Eager Loading*/
-            ////await QueryRelatedRecords();
-
-            /* Projections to Other Data Types or Ananymous Types */
-            ////await SelectOneProperty();
-            ////await AnonymousProjection();
-            ////await StronglyTypedProjection();
-
-            /* Filter Based on Related Data */
-            ////await FilteringWithRelatedData();
-
-            /* Querying Views */
-            ////await QueryView();
-
-            /* Query With Raw SQL */
-            ////await RawSQLQuery();
-
-            /* Query Stored Procedures */
-            ////await ExecStoredProcedure();
-
-            /* RAW SQL Non-Query Commands */
-            ////await ExecuteNonQueryCommand();
-
-
-            Console.WriteLine("Press Any Key To End....");
-            Console.ReadKey();
-        }
-
-        ////async static Task ExecuteNonQueryCommand()
-        ////{
-        ////    var teamId = 10;
-        ////    var affectedRows = await context.Database.ExecuteSqlRawAsync("exec sp_DeleteTeamById {0}", teamId);
-
-        ////    var teamId2 = 12;
-        ////    var affectedRows2 = await context.Database.ExecuteSqlInterpolatedAsync($"exec sp_DeleteTeamById {teamId2}");
-        ////}
-
-        ////async static Task ExecStoredProcedure()
-        ////{
-        ////    var teamId = 3;
-        ////    var result = await context.Coaches.FromSqlRaw("EXEC dbo.sp_GetTeamCoach {0}", teamId).ToListAsync();
-        ////}
-
-        ////async static Task RawSQLQuery()
-        ////{
-        ////    var name = "AS Roma";
-        ////    var teams1 = await context.Teams.FromSqlRaw($"Select * from Teams where name = '{name}'")
-        ////        .Include(q => q.Coach).ToListAsync();
-
-        ////    var teams2 = await context.Teams.FromSqlInterpolated($"Select * from Teams where name = {name}").ToListAsync();
-
-        ////}
-
-        ////async static Task QueryView()
-        ////{
-        ////    var details = await context.TeamsCoachesLeagues.ToListAsync();
-        ////}
-
-        ////async static Task FilteringWithRelatedData()
-        ////{
-        ////    var leagues = await context.Leagues.Where(q => q.Teams.Any(x => x.Name.Contains("Bay"))).ToListAsync();
-        ////}
-
-        ////async static Task SelectOneProperty()
-        ////{
-        ////    var teams = await context.Teams.Select(q => q.Name).ToListAsync();
-        ////}
-
-        ////async static Task AnonymousProjection()
-        ////{
-        ////    var teams = await context.Teams.Include(q => q.Coach).Select(
-        ////        q => 
-        ////        new { 
-        ////                TeamName = q.Name, 
-        ////                CoachName = q.Coach.Name
-        ////            }
-        ////        ).ToListAsync();
-
-        ////    foreach (var item in teams)
-        ////    {
-        ////        Console.WriteLine($"Team: {item.TeamName} | Coach: {item.CoachName}");
-        ////    }
-        ////}
-
-        ////async static Task StronglyTypedProjection()
-        ////{
-        ////    var teams = await context.Teams.Include(q => q.Coach).Include(q => q.League).Select(
-        ////        q =>
-        ////        new TeamsCoachesLeaguesView {
-        ////            Name = q.Name,
-        ////            CoachName = q.Coach.Name,
-        ////            LeagueName = q.League.Name
-        ////        }
-        ////        ).ToListAsync();
-        ////    foreach (var item in teams)
-        ////    {
-        ////        Console.WriteLine($"Team: {item.Name} | Coach: {item.CoachName} | League: {item.LeagueName}");
-        ////    }
-        ////}
-
-        ////static async Task QueryRelatedRecords()
-        ////{
-        ////    //// Get Many Related Records - Leagues -> Teams
-        ////    var leagues = await context.Leagues.Include(q => q.Teams).ToListAsync();
-
-        ////    //// Get One Related Record - Team -> Coach
-        ////    var team = await context.Teams
-        ////        .Include(q => q.Coach)
-        ////        .FirstOrDefaultAsync(q => q.Id == 3);
-
-        ////    //// Get 'Grand Children' Related Record - Team -> Matches -> Home/Away Team
-        ////    var teamsWithMatchesAndOpponents = await context.Teams
-        ////        .Include(q => q.AwayMatches).ThenInclude(q => q.HomeTeam).ThenInclude(q => q.Coach)
-        ////        .Include(q => q.HomeMatches).ThenInclude(q => q.AwayTeam).ThenInclude(q => q.Coach)
-        ////        .FirstOrDefaultAsync(q => q.Id == 1);
-
-        ////    //// Get Includes with filters
-        ////    var teams = await context.Teams
-        ////        .Where(q => q.HomeMatches.Count > 0)
-        ////        .Include(q => q.Coach)
-        ////        .ToListAsync(); 
-        ////}
-
-
-        ////private static async Task TrackingVsNoTracking()
-        ////{
-        ////    var withTracking = await context.Teams.FirstOrDefaultAsync(q => q.Id == 2);
-        ////    var withNoTracking = await context.Teams.AsNoTracking().FirstOrDefaultAsync(q => q.Id == 8);
-
-        ////    withTracking.Name = "Inter Milan";
-        ////    withNoTracking.Name = "Rivoli United";
-
-        ////    var entriesBeforeSave = context.ChangeTracker.Entries();
-
-        ////    await context.SaveChangesAsync();
-
-        ////    var entriesAfterSave = context.ChangeTracker.Entries();
-        ////}
-
-        ////private static async Task SimpleDelete()
-        ////{
-        ////    var league = await context.Leagues.FindAsync(4);
-        ////    context.Leagues.Remove(league);
-        ////    await context.SaveChangesAsync();
-        ////}
-
-        ////private static async Task DeleteWithRelationship()
-        ////{
-        ////    var league = await context.Leagues.FindAsync(9);
-        ////    context.Leagues.Remove(league);
-        ////    await context.SaveChangesAsync();
-        ////}
-
-        ////private static async Task SimpleUpdateTeamRecord()
-        ////{
-        ////    var team = new Team
-        ////    {
-        ////        Id = 7,
-        ////        Name = "Seba United FC",
-        ////        LeagueId = 2
-        ////    };
-        ////    context.Teams.Update(team);
-        ////    await context.SaveChangesAsync("Test Update User");
-        ////}
-
-        ////private static async Task GetRecord()
-        ////{
-        ////    ////Retrieve Record
-        ////    var league = await context.Leagues.FindAsync(3);
-        ////    Console.WriteLine($"{league.Id} - {league.Name}");
-        ////}
-
-        ////private static async Task SimpleUpdateLeagueRecord()
-        ////{
-        ////    ////Retrieve Record
-        ////    var league = await context.Leagues.FindAsync(20);
-        ////    ///Make Record Changes
-        ////    league.Name = "Scottish Premiership";
-        ////    ///Save Changes
-        ////    await context.SaveChangesAsync();
-
-        ////    await GetRecord();
-
-        ////}
-
-        ////static async Task AlternativeLinqSyntax()
-        ////{
-        ////    Console.Write($"Enter Team Name (Or Part Of): ");
-        ////    var teamName = Console.ReadLine();
-        ////    var teams = await (from i in context.Teams
-        ////                       where EF.Functions.Like(i.Name, $"%{teamName}%")
-        ////                       select i).ToListAsync();
-
-        ////    foreach (var team in teams)
-        ////    {
-        ////        Console.WriteLine($"{team.Id} - {team.Name}");
-        ////    }
-        ////}
-
-        ////static async Task AdditionalExecutionMethods()
-        ////{
-        ////    //// These methods also have non-async
-        ////    var leagues = context.Leagues;
-        ////    var list = await leagues.ToListAsync();
-        ////    var first = await leagues.FirstAsync();
-        ////    var firstOrDefault = await leagues.FirstOrDefaultAsync();
-        ////    var single = await leagues.SingleAsync();
-        ////    var singleOrDefault = await leagues.SingleOrDefaultAsync();
-
-        ////    var count = await leagues.CountAsync();
-        ////    var longCount = await leagues.LongCountAsync();
-        ////    var min = await leagues.MinAsync();
-        ////    var max = await leagues.MaxAsync();
-
-        ////    //// DbSet Method that will execute
-        ////    var league = await leagues.FindAsync(1);
-
-        ////}
-
-        ////static async Task QueryFilters()
-        ////{
-        ////    Console.Write($"Enter League Name (Or Part Of): ");
-        ////    var leagueName = Console.ReadLine();
-        ////    var exactMatches= await context.Leagues.Where(q => q.Name.Equals(leagueName)).ToListAsync();
-        ////    foreach (var league in exactMatches)
-        ////    {
-        ////        Console.WriteLine($"{league.Id} - {league.Name}");
-        ////    }
-
-        ////    ////var partialMatches = await context.Leagues.Where(q => q.Name.Contains(leagueName)).ToListAsync();
-        ////    var partialMatches = await context.Leagues.Where(q => EF.Functions.Like(q.Name, $"%{leagueName}%")).ToListAsync();
-        ////    foreach (var league in partialMatches)
-        ////    {
-        ////        Console.WriteLine($"{league.Id} - {league.Name}");
-        ////    }
-        ////}
-
-        ////static async Task SimpleSelectQuery()
-        ////{
-        ////    //// Smartest most efficient way to get results
-        ////    var leagues = await context.Leagues.ToListAsync();
-        ////    foreach (var league in leagues)
-        ////    {
-        ////        Console.WriteLine($"{league.Id} - {league.Name}");
-        ////    }
-
-        ////    //// Inefficient way to get results. Keeps connection open until completed and might create lock on table
-        ////    ////foreach (var league in context.Leagues)
-        ////    ////{
-        ////    ////    Console.WriteLine($"{league.Id} - {league.Name}");
-        ////    ////}
-
-        ////}
-
-        static async Task AddNewLeague()
-        {                    
-            //// Adding a new League Object
-            var league = new League { Name = "Audit Testing League" };
-            await context.Leagues.AddAsync(league);
-            await context.SaveChangesAsync("Test Audit Create User");
-
-            //// Function To add new teams related to the new league object. 
-            await AddTeamsWithLeague(league);
-            await context.SaveChangesAsync();
-         
-        }
-
-        static async Task AddNewLeagueTransaction()
-        {
-            var transaction = context.Database.BeginTransaction();
-
-            try
-            {
-                //// Adding a new League Object
-                var league = new League { Name = "Audit Testing League" };
-                await context.Leagues.AddAsync(league);
-                await context.SaveChangesAsync("Test Audit Create User");
-
-                //// Function To add new teams related to the new league object. 
-                await AddTeamsWithLeague(league);
-                await context.SaveChangesAsync();
-
-                transaction.Commit();
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine(ex.Message);
-            }
-
-        }
-
-        static async Task AddNewLeagueTransactionWithRollback()
-        {
-            var transaction = context.Database.BeginTransaction();
-
-            try
-            {
-                //// Adding a new League Object
-                var league = new League { Name = "Audit Testing League" };
-                await context.Leagues.AddAsync(league);
-                await context.SaveChangesAsync("Test Audit Create User");
-
-                await transaction.CreateSavepointAsync("SavedLeague");
-
-                //// Function To add new teams related to the new league object. 
-                await AddTeamsWithLeague(league);
-                await context.SaveChangesAsync();
-
-                transaction.Commit();
-            }
-            catch (Exception ex)
-            {
-                await transaction.RollbackToSavepointAsync("SavedLeague");
-                Console.WriteLine(ex.Message);
-            }
-
-        }
-
-        static async Task AddTeamsWithLeague(League league)
-        {
-            var teams = new List<Team>
-            {
-                new Team
-                {
-                    Name = "Juventus",
-                    LeagueId = league.Id
-                },
-                new Team
-                {
-                    Name = "AC Milan",
-                    LeagueId = league.Id
-                },
-                new Team
-                {
-                    Name = "AS Roma",
-                    League = league
-                }
-            };
-
-            //// Operation to add multiple objects to database in one call.
-            await context.AddRangeAsync(teams);
-        }
-
-        ////static async Task AddNewTeamsWithLeague()
-        ////{
-        ////    var league = new League { Name = "Bundesliga" };
-        ////    var team = new Team { Name = "Bayern Munich", League = league };
-        ////    await context.AddAsync(team);
-        ////    await context.SaveChangesAsync();
-        ////}
-
-        ////static async Task AddNewTeamWithLeagueId()
-        ////{
-        ////    var team = new Team { Name = "Fiorentina", LeagueId = 8 };
-        ////    await context.AddAsync(team);
-        ////    await context.SaveChangesAsync();
-        ////}
-
-        ////static async Task AddNewLeagueWithTeams()
-        ////{
-        ////    var teams = new List<Team> { 
-        ////        new Team 
-        ////        { 
-        ////            Name = "Rivoli United"
-        ////        },
-        ////        new Team
-        ////        {
-        ////            Name = "Waterhouse FC"
-        ////        },
-        ////    };
-        ////    var league = new League { Name = "CIFA", Teams = teams };
-        ////    await context.AddAsync(league);
-        ////    await context.SaveChangesAsync();
-        ////}
-
-        ////static async Task AddNewMatches()
-        ////{
-        ////    var matches = new List<Match> 
-        ////    { 
-        ////        new Match
-        ////        {
-        ////            AwayTeamId = 1, HomeTeamId = 2, Date = new DateTime(2021, 10, 28)
-        ////        },
-        ////        new Match
-        ////        {
-        ////            AwayTeamId = 8, HomeTeamId = 7, Date = DateTime.Now
-        ////        },
-        ////        new Match
-        ////        {
-        ////            AwayTeamId = 8, HomeTeamId = 7, Date = DateTime.Now
-        ////        }
-        ////    };
-        ////    await context.AddRangeAsync(matches);
-        ////    await context.SaveChangesAsync();
-        ////}
-        ////private static async Task AddNewCoach()
-        ////{
-        ////    var coach1 = new Coach { Name = "Jose Mourinho", TeamId = 3 };
-
-        ////    await context.AddAsync(coach1);
-
-        ////    var coach2 = new Coach { Name = "Antonio Conte" };
-
-        ////    await context.AddAsync(coach2);
-        ////    await context.SaveChangesAsync();
-        ////}
+        //// Adding a new League Object
+        var league = new League { Name = "Audit Testing League" };
+        await context.Leagues.AddAsync(league);
+        await context.SaveChangesAsync("Test Audit Create User");
+
+        //// Function To add new teams related to the new league object. 
+        await AddTeamsWithLeague(league);
+        await context.SaveChangesAsync();
+
+        transaction.Commit();
+    }
+    catch (Exception ex)
+    {
+        Console.WriteLine(ex.Message);
     }
 }
+
+async Task AddNewLeagueTransactionWithRollback()
+{
+    var transaction = context.Database.BeginTransaction();
+
+    try
+    {
+        //// Adding a new League Object
+        var league = new League { Name = "Audit Testing League" };
+        await context.Leagues.AddAsync(league);
+        await context.SaveChangesAsync("Test Audit Create User");
+
+        await transaction.CreateSavepointAsync("SavedLeague");
+
+        //// Function To add new teams related to the new league object. 
+        await AddTeamsWithLeague(league);
+        await context.SaveChangesAsync();
+
+        transaction.Commit();
+    }
+    catch (Exception ex)
+    {
+        await transaction.RollbackToSavepointAsync("SavedLeague");
+        Console.WriteLine(ex.Message);
+    }
+}
+
+async Task AddTeamsWithLeague(League league)
+{
+    var teams = new List<Team>
+        {
+            new Team
+            {
+                Name = "Juventus",
+                LeagueId = league.Id
+            },
+            new Team
+            {
+                Name = "AC Milan",
+                LeagueId = league.Id
+            },
+            new Team
+            {
+                Name = "AS Roma",
+                League = league
+            }
+        };
+
+    //// Operation to add multiple objects to database in one call.
+    await context.AddRangeAsync(teams);
+}
+////static async Task AddNewTeamsWithLeague()
+////{
+////    var league = new League { Name = "Bundesliga" };
+////    var team = new Team { Name = "Bayern Munich", League = league };
+////    await context.AddAsync(team);
+////    await context.SaveChangesAsync();
+////}
+
+////static async Task AddNewTeamWithLeagueId()
+////{
+////    var team = new Team { Name = "Fiorentina", LeagueId = 8 };
+////    await context.AddAsync(team);
+////    await context.SaveChangesAsync();
+////}
+
+////static async Task AddNewLeagueWithTeams()
+////{
+////    var teams = new List<Team> { 
+////        new Team 
+////        { 
+////            Name = "Rivoli United"
+////        },
+////        new Team
+////        {
+////            Name = "Waterhouse FC"
+////        },
+////    };
+////    var league = new League { Name = "CIFA", Teams = teams };
+////    await context.AddAsync(league);
+////    await context.SaveChangesAsync();
+////}
+
+////static async Task AddNewMatches()
+////{
+////    var matches = new List<Match> 
+////    { 
+////        new Match
+////        {
+////            AwayTeamId = 1, HomeTeamId = 2, Date = new DateTime(2021, 10, 28)
+////        },
+////        new Match
+////        {
+////            AwayTeamId = 8, HomeTeamId = 7, Date = DateTime.Now
+////        },
+////        new Match
+////        {
+////            AwayTeamId = 8, HomeTeamId = 7, Date = DateTime.Now
+////        }
+////    };
+////    await context.AddRangeAsync(matches);
+////    await context.SaveChangesAsync();
+////}
+////private static async Task AddNewCoach()
+////{
+////    var coach1 = new Coach { Name = "Jose Mourinho", TeamId = 3 };
+
+////    await context.AddAsync(coach1);
+
+////    var coach2 = new Coach { Name = "Antonio Conte" };
+
+////    await context.AddAsync(coach2);
+////    await context.SaveChangesAsync();
+////}

--- a/EntityFrameworkNet5.Data/AuditEntry.cs
+++ b/EntityFrameworkNet5.Data/AuditEntry.cs
@@ -2,40 +2,32 @@
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Newtonsoft.Json;
 using System.Collections.Generic;
-using System.Linq;
 
-namespace EntityFrameworkNet5.Data
+namespace EntityFrameworkNet5.Data;
+
+class AuditEntry
 {
-    internal class AuditEntry
+    public AuditEntry(EntityEntry entityEntry) =>
+        EntityEntry = entityEntry;
+
+    public EntityEntry EntityEntry { get; }
+
+    public string Action { get; set; }
+    public string TableName { get; set; }
+    public Dictionary<string, object> KeyValues { get; set; } = new Dictionary<string, object>();
+    public Dictionary<string, object> OldValues { get; set; } = new Dictionary<string, object>();
+    public Dictionary<string, object> NewValues { get; set; } = new Dictionary<string, object>();
+    public List<PropertyEntry> TemporaryProperties { get; } = new List<PropertyEntry>();
+
+    public bool HasTemporaryProperties => TemporaryProperties.Count > 0;
+
+    public Audit ToAudit() => new()
     {
-        public AuditEntry(EntityEntry entityEntry)
-        {
-            EntityEntry = entityEntry;
-        }
-
-        public EntityEntry EntityEntry { get; }
-
-        public string Action { get; set; }
-        public string TableName { get; set; }
-        public Dictionary<string, object> KeyValues { get; set; } = new Dictionary<string, object>();
-        public Dictionary<string, object> OldValues { get; set; } = new Dictionary<string, object>();
-        public Dictionary<string, object> NewValues { get; set; } = new Dictionary<string, object>();
-        public List<PropertyEntry> TemporaryProperties { get; } = new List<PropertyEntry>();
-
-        public bool HasTemporaryProperties => TemporaryProperties.Any();
-
-        public Audit ToAudit()
-        {
-            var audit = new Audit {
-                DateTime = System.DateTime.Now,
-                TableName = TableName,
-                KeyValues = JsonConvert.SerializeObject(KeyValues),
-                OldValues = OldValues.Count == 0 ? null : JsonConvert.SerializeObject(OldValues),
-                NewValues = NewValues.Count == 0 ? null : JsonConvert.SerializeObject(NewValues),
-                Action = Action
-            };
-            return audit;
-        }
-
-    }
+        DateTime = System.DateTime.Now,
+        TableName = TableName,
+        KeyValues = JsonConvert.SerializeObject(KeyValues),
+        OldValues = OldValues.Count == 0 ? null : JsonConvert.SerializeObject(OldValues),
+        NewValues = NewValues.Count == 0 ? null : JsonConvert.SerializeObject(NewValues),
+        Action = Action
+    };
 }

--- a/EntityFrameworkNet5.Data/Configurations/Entities/CoachConfiguration.cs
+++ b/EntityFrameworkNet5.Data/Configurations/Entities/CoachConfiguration.cs
@@ -1,39 +1,33 @@
 ﻿using EntityFrameworkNet5.Domain;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace EntityFrameworkNet5.Data.Configurations.Entities
+namespace EntityFrameworkNet5.Data.Configurations.Entities;
+
+public class CoachConfiguration : IEntityTypeConfiguration<Coach>
 {
-    public class CoachConfiguration : IEntityTypeConfiguration<Coach>
+    public void Configure(EntityTypeBuilder<Coach> builder)
     {
-        public void Configure(EntityTypeBuilder<Coach> builder)
-        {
-            ////builder.Property(p => p.Name).HasMaxLength(50);
-            builder.HasIndex(h => new { h.Name, h.TeamId }).IsUnique();
-            builder.HasData(
-                    new Coach
-                    {
-                        Id = 20,
-                        Name = "Trevoir Williams",
-                        TeamId = 20
-                    },
-                    new Coach
-                    {
-                        Id = 21,
-                        Name = "Trevoir Williams - Sample 1",
-                        TeamId = 21
-                    }, new Coach
-                    {
-                        Id = 22,
-                        Name = "Trevoir Williams - Sample 2",
-                        TeamId = 22
-                    }
-                );
-        }
+        ////builder.Property(p => p.Name).HasMaxLength(50);
+        builder.HasIndex(h => new { h.Name, h.TeamId }).IsUnique();
+        builder.HasData(
+                new Coach
+                {
+                    Id = 20,
+                    Name = "Trevoir Williams",
+                    TeamId = 20
+                },
+                new Coach
+                {
+                    Id = 21,
+                    Name = "Trevoir Williams - Sample 1",
+                    TeamId = 21
+                }, new Coach
+                {
+                    Id = 22,
+                    Name = "Trevoir Williams - Sample 2",
+                    TeamId = 22
+                }
+            );
     }
 }

--- a/EntityFrameworkNet5.Data/Configurations/Entities/LeagueConfiguration.cs
+++ b/EntityFrameworkNet5.Data/Configurations/Entities/LeagueConfiguration.cs
@@ -1,28 +1,22 @@
 ﻿using EntityFrameworkNet5.Domain;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace EntityFrameworkNet5.Data.Configurations.Entities
+namespace EntityFrameworkNet5.Data.Configurations.Entities;
+
+public class LeagueConfiguration : IEntityTypeConfiguration<League>
 {
-    public class LeagueConfiguration : IEntityTypeConfiguration<League>
+    public void Configure(EntityTypeBuilder<League> builder)
     {
-        public void Configure(EntityTypeBuilder<League> builder)
-        {
-            ////builder.Property(p => p.Name).HasMaxLength(50);
-            builder.HasIndex(h => h.Name);
+        ////builder.Property(p => p.Name).HasMaxLength(50);
+        builder.HasIndex(h => h.Name);
 
-            builder.HasData(
-                    new League
-                    {
-                        Id = 20,
-                        Name = "Sample League",
-                    }
-                );
-        }
+        builder.HasData(
+                new League
+                {
+                    Id = 20,
+                    Name = "Sample League"
+                }
+            );
     }
 }

--- a/EntityFrameworkNet5.Data/Configurations/Entities/TeamConfiguration.cs
+++ b/EntityFrameworkNet5.Data/Configurations/Entities/TeamConfiguration.cs
@@ -1,56 +1,46 @@
 ﻿using EntityFrameworkNet5.Domain;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace EntityFrameworkNet5.Data.Configurations.Entities
+namespace EntityFrameworkNet5.Data.Configurations.Entities;
+
+public class TeamConfiguration : IEntityTypeConfiguration<Team>
 {
-    public class TeamConfiguration : IEntityTypeConfiguration<Team>
+    public void Configure(EntityTypeBuilder<Team> builder)
     {
-        public void Configure(EntityTypeBuilder<Team> builder)
-        {
-            ////builder.Property(p => p.Name).HasMaxLength(50).IsRequired();
-            builder.HasIndex(h => h.Name).IsUnique();
-            builder.HasMany(m => m.HomeMatches)
-                .WithOne(m => m.HomeTeam)
-                .HasForeignKey(m => m.HomeTeamId)
-                .IsRequired()
-                .OnDelete(DeleteBehavior.Restrict);
+        ////builder.Property(p => p.Name).HasMaxLength(50).IsRequired();
+        builder.HasIndex(h => h.Name).IsUnique();
+        builder.HasMany(m => m.HomeMatches)
+            .WithOne(m => m.HomeTeam)
+            .HasForeignKey(m => m.HomeTeamId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Restrict);
 
-            builder.HasMany(m => m.AwayMatches)
-                .WithOne(m => m.AwayTeam)
-                .HasForeignKey(m => m.AwayTeamId)
-                .IsRequired()
-                .OnDelete(DeleteBehavior.Restrict);
+        builder.HasMany(m => m.AwayMatches)
+            .WithOne(m => m.AwayTeam)
+            .HasForeignKey(m => m.AwayTeamId)
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Restrict);
 
-            builder.HasData(
-                    new Team
-                    {
-                        Id = 20,
-                        Name = "Trevoir Williams - Sample Team",
-                        LeagueId = 20
-                    },
-                    new Team
-                    {
-                        Id = 21,
-                        Name = "Trevoir Williams - Sample Team",
-                        LeagueId = 20
-
-                    },
-                    new Team
-                    {
-                        Id = 22,
-                        Name = "Trevoir Williams - Sample Team",
-                        LeagueId = 20
-
-                    }
-                );
-
-
-        }
+        builder.HasData(
+                new Team
+                {
+                    Id = 20,
+                    Name = "Trevoir Williams - Sample Team",
+                    LeagueId = 20
+                },
+                new Team
+                {
+                    Id = 21,
+                    Name = "Trevoir Williams - Sample Team",
+                    LeagueId = 20
+                },
+                new Team
+                {
+                    Id = 22,
+                    Name = "Trevoir Williams - Sample Team",
+                    LeagueId = 20
+                }
+            );
     }
 }

--- a/EntityFrameworkNet5.Data/FootballLeageDbContext.cs
+++ b/EntityFrameworkNet5.Data/FootballLeageDbContext.cs
@@ -5,55 +5,48 @@ using Microsoft.Extensions.Logging;
 using System;
 using System.Linq;
 
-namespace EntityFrameworkNet5.Data
+namespace EntityFrameworkNet5.Data;
+
+public class FootballLeageDbContext : AuditableFootballLeageDbContext
 {
-    public class FootballLeageDbContext : AuditableFootballLeageDbContext
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) =>
+        optionsBuilder.UseSqlServer("Data Source=(localdb)\\MSSQLLocalDB; Initial Catalog=FootballLeage_EfCore", sqlOptions =>
+                sqlOptions.EnableRetryOnFailure(maxRetryCount: 5, maxRetryDelay: TimeSpan.FromSeconds(30), errorNumbersToAdd: null))
+            .LogTo(Console.WriteLine, new[] { DbLoggerCategory.Database.Command.Name }, LogLevel.Information)
+            .EnableSensitiveDataLogging();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
-        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        modelBuilder.Entity<TeamsCoachesLeaguesView>().HasNoKey().ToView("TeamsCoachesLeagues");
+        modelBuilder.ApplyConfiguration(new LeagueConfiguration());
+        modelBuilder.ApplyConfiguration(new TeamConfiguration());
+        modelBuilder.ApplyConfiguration(new CoachConfiguration());
+
+        //Set all FK relationships should be restrict
+        var foreignKeys = modelBuilder.Model.GetEntityTypes()
+            .SelectMany(x => x.GetForeignKeys())
+            .Where(x => !x.IsOwnership && x.DeleteBehavior == DeleteBehavior.Cascade);
+
+        foreach (var fk in foreignKeys)
         {
-            optionsBuilder.UseSqlServer("Data Source=(localdb)\\MSSQLLocalDB; Initial Catalog=FootballLeage_EfCore", sqlOptions => 
-                { 
-                    sqlOptions.EnableRetryOnFailure(maxRetryCount: 5, maxRetryDelay: TimeSpan.FromSeconds(30), errorNumbersToAdd: null);
-                })
-                .LogTo(Console.WriteLine, new[] { DbLoggerCategory.Database.Command.Name }, LogLevel.Information)
-                .EnableSensitiveDataLogging();
+            fk.DeleteBehavior = DeleteBehavior.Restrict;
         }
 
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            modelBuilder.Entity<TeamsCoachesLeaguesView>().HasNoKey().ToView("TeamsCoachesLeagues");
-            modelBuilder.ApplyConfiguration(new LeagueConfiguration());
-            modelBuilder.ApplyConfiguration(new TeamConfiguration());
-            modelBuilder.ApplyConfiguration(new CoachConfiguration());
-
-            //Set all FK relationships should be restrict
-            var foreignKeys = modelBuilder.Model.GetEntityTypes()
-                .SelectMany(x => x.GetForeignKeys())
-                .Where(x => !x.IsOwnership && x.DeleteBehavior == DeleteBehavior.Cascade);
-
-            foreach (var fk in foreignKeys)
-            {
-                fk.DeleteBehavior = DeleteBehavior.Restrict;
-            }
-
-            //Indicate which has a History Table
-            modelBuilder
-                .Entity<Team>()
-                .ToTable("Teams", b => b.IsTemporal());
-
-        }
-
-        protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
-        {
-            // Pre-convention model configuration goes here
-            ////configurationBuilder.Properties<string>().HaveMaxLength(50);
-        }
-
-        public DbSet<Team> Teams { get; set; }
-        public DbSet<League> Leagues { get; set; }
-        public DbSet<Match> Matches { get; set; }
-        public DbSet<Coach> Coaches { get; set; }
-        public DbSet<TeamsCoachesLeaguesView> TeamsCoachesLeagues { get; set; }
-
+        //Indicate which has a History Table
+        modelBuilder
+            .Entity<Team>()
+            .ToTable("Teams", b => b.IsTemporal());
     }
+
+    protected override void ConfigureConventions(ModelConfigurationBuilder configurationBuilder)
+    {
+        // Pre-convention model configuration goes here
+        ////configurationBuilder.Properties<string>().HaveMaxLength(50);
+    }
+
+    public DbSet<Team> Teams { get; set; }
+    public DbSet<League> Leagues { get; set; }
+    public DbSet<Match> Matches { get; set; }
+    public DbSet<Coach> Coaches { get; set; }
+    public DbSet<TeamsCoachesLeaguesView> TeamsCoachesLeagues { get; set; }
 }

--- a/EntityFrameworkNet5.Domain/Audit.cs
+++ b/EntityFrameworkNet5.Domain/Audit.cs
@@ -1,19 +1,14 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace EntityFrameworkNet5.Domain
+namespace EntityFrameworkNet5.Domain;
+
+public class Audit
 {
-    public class Audit
-    {
-        public int Id { get; set; }
-        public string Action { get; set; }
-        public string TableName { get; set; }
-        public DateTime DateTime { get; set; }
-        public string KeyValues { get; set; }
-        public string OldValues { get; set; }
-        public string NewValues { get; set; }
-    }
+    public int Id { get; set; }
+    public string Action { get; set; }
+    public string TableName { get; set; }
+    public DateTime DateTime { get; set; }
+    public string KeyValues { get; set; }
+    public string OldValues { get; set; }
+    public string NewValues { get; set; }
 }

--- a/EntityFrameworkNet5.Domain/Coach.cs
+++ b/EntityFrameworkNet5.Domain/Coach.cs
@@ -1,17 +1,10 @@
 ﻿using EntityFrameworkNet5.Domain.Common;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
+namespace EntityFrameworkNet5.Domain;
 
-namespace EntityFrameworkNet5.Domain
+public class Coach : BaseDomainObject
 {
-    public class Coach : BaseDomainObject
-    {
-        public string Name { get; set; }
-        public int? TeamId { get; set; }
-        ////public virtual Team Team { get; set; }
-    }
+    public string Name { get; set; }
+    public int? TeamId { get; set; }
+    ////public virtual Team Team { get; set; }
 }

--- a/EntityFrameworkNet5.Domain/Common/BaseDomainObject.cs
+++ b/EntityFrameworkNet5.Domain/Common/BaseDomainObject.cs
@@ -1,18 +1,13 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace EntityFrameworkNet5.Domain.Common
+namespace EntityFrameworkNet5.Domain.Common;
+
+public abstract class BaseDomainObject
 {
-    public abstract class BaseDomainObject
-    {
-        public int Id { get; set; }
-        public DateTime CreatedDate { get; set; }
+    public int Id { get; set; }
+    public DateTime CreatedDate { get; set; }
 
-        public DateTime ModifiedDate { get; set; }
-        public string CreatedBy { get; set; }
-        public string ModifiedBy { get; set; }
-    }
+    public DateTime ModifiedDate { get; set; }
+    public string CreatedBy { get; set; }
+    public string ModifiedBy { get; set; }
 }

--- a/EntityFrameworkNet5.Domain/EntityFrameworkNet5.Domain.csproj
+++ b/EntityFrameworkNet5.Domain/EntityFrameworkNet5.Domain.csproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
 </Project>

--- a/EntityFrameworkNet5.Domain/League.cs
+++ b/EntityFrameworkNet5.Domain/League.cs
@@ -1,15 +1,10 @@
 ﻿using EntityFrameworkNet5.Domain.Common;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace EntityFrameworkNet5.Domain
+namespace EntityFrameworkNet5.Domain;
+
+public class League : BaseDomainObject
 {
-    public class League : BaseDomainObject
-    {
-        public string Name { get; set; }
-        public List<Team> Teams { get; set; }
-    }
+    public string Name { get; set; }
+    public List<Team> Teams { get; set; }
 }

--- a/EntityFrameworkNet5.Domain/Match.cs
+++ b/EntityFrameworkNet5.Domain/Match.cs
@@ -1,23 +1,18 @@
 ﻿using EntityFrameworkNet5.Domain.Common;
 using Microsoft.EntityFrameworkCore;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace EntityFrameworkNet5.Domain
+namespace EntityFrameworkNet5.Domain;
+
+public class Match : BaseDomainObject
 {
-    public class Match : BaseDomainObject
-    {
-        public int HomeTeamId { get; set; }
-        public virtual Team HomeTeam { get; set; }
-        public int AwayTeamId { get; set; }
-        public virtual Team AwayTeam { get; set; }
+    public int HomeTeamId { get; set; }
+    public virtual Team HomeTeam { get; set; }
+    public int AwayTeamId { get; set; }
+    public virtual Team AwayTeam { get; set; }
 
-        [Precision(18, 2)]
-        public decimal TicketPrice { get; set; }
+    [Precision(18, 2)]
+    public decimal TicketPrice { get; set; }
 
-        public DateTime Date { get; set; }
-    }
+    public DateTime Date { get; set; }
 }

--- a/EntityFrameworkNet5.Domain/Models/TeamDetail.cs
+++ b/EntityFrameworkNet5.Domain/Models/TeamDetail.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace EntityFrameworkNet5.Domain.Models;
 
-namespace EntityFrameworkNet5.Domain.Models
+public class TeamDetail
 {
-    public class TeamDetail
-    {
-        public string Name { get; set; }
-        public string CoachName { get; set; }
-        public string LeagueName { get; set; }
-    }
+    public string Name { get; set; }
+    public string CoachName { get; set; }
+    public string LeagueName { get; set; }
 }

--- a/EntityFrameworkNet5.Domain/Team.cs
+++ b/EntityFrameworkNet5.Domain/Team.cs
@@ -1,20 +1,15 @@
 ﻿using EntityFrameworkNet5.Domain.Common;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace EntityFrameworkNet5.Domain
+namespace EntityFrameworkNet5.Domain;
+
+public class Team : BaseDomainObject
 {
-    public class Team : BaseDomainObject
-    {
-        public string Name { get; set; }
-        public int LeagueId { get; set; }
-        public virtual League League { get; set; }
-        public virtual Coach Coach { get; set; }
+    public string Name { get; set; }
+    public int LeagueId { get; set; }
+    public virtual League League { get; set; }
+    public virtual Coach Coach { get; set; }
 
-        public virtual List<Match> HomeMatches { get; set; }
-        public virtual List<Match> AwayMatches { get; set; }
-    }
+    public virtual List<Match> HomeMatches { get; set; }
+    public virtual List<Match> AwayMatches { get; set; }
 }

--- a/EntityFrameworkNet5.Domain/TeamsCoachesLeaguesView.cs
+++ b/EntityFrameworkNet5.Domain/TeamsCoachesLeaguesView.cs
@@ -1,15 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿namespace EntityFrameworkNet5.Domain;
 
-namespace EntityFrameworkNet5.Domain
+public class TeamsCoachesLeaguesView
 {
-    public class TeamsCoachesLeaguesView
-    {
-        public string Name { get; set; }
-        public string CoachName { get; set; }
-        public string LeagueName { get; set; }
-    }
+    public string Name { get; set; }
+    public string CoachName { get; set; }
+    public string LeagueName { get; set; }
 }

--- a/EntityFrameworkNet5.sln
+++ b/EntityFrameworkNet5.sln
@@ -9,7 +9,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFrameworkNet5.Data", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFrameworkNet5.Domain", "EntityFrameworkNet5.Domain\EntityFrameworkNet5.Domain.csproj", "{E9D9982F-24DA-4DB2-A59E-97509B548EAA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "EntityFrameworkNet6.ConsoleApp", "EntityFrameworkNet6.ConsoleApp\EntityFrameworkNet6.ConsoleApp.csproj", "{0B21A3EB-6DFB-4FE5-8285-FEBD1731F87A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EntityFrameworkNet6.ConsoleApp", "EntityFrameworkNet6.ConsoleApp\EntityFrameworkNet6.ConsoleApp.csproj", "{0B21A3EB-6DFB-4FE5-8285-FEBD1731F87A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{AF8C0345-76C1-43F9-A7FB-675E8ECC7933}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/EntityFrameworkNet6.ConsoleApp/EntityFrameworkNet6.ConsoleApp.csproj
+++ b/EntityFrameworkNet6.ConsoleApp/EntityFrameworkNet6.ConsoleApp.csproj
@@ -8,13 +8,6 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
-
-	<ItemGroup>
 		<ProjectReference Include="..\EntityFrameworkNet5.Data\EntityFrameworkNet5.Data.csproj" />
 	</ItemGroup>
 </Project>

--- a/EntityFrameworkNet6.ConsoleApp/Program.cs
+++ b/EntityFrameworkNet6.ConsoleApp/Program.cs
@@ -1,11 +1,8 @@
 ﻿/* Simple Insert Operation Methods */
 using EntityFrameworkNet5.Data;
-using EntityFrameworkNet5.Domain;
 using Microsoft.EntityFrameworkCore;
 
-
-FootballLeageDbContext context = new FootballLeageDbContext();
-
+var context = new FootballLeageDbContext();
 
 //await AddNewLeague();
 //await AddNewTeamsWithLeague();
@@ -68,8 +65,6 @@ FootballLeageDbContext context = new FootballLeageDbContext();
 /* RAW SQL Non-Query Commands */
 ////await ExecuteNonQueryCommand();
 
-
-
 /* Select History Of Teams Table */
 await TeamsQueries();
 await TeamsHistoryTemporalQueries();
@@ -98,8 +93,6 @@ async Task TeamsHistoryTemporalQueries()
         Console.WriteLine($"Id: {item.Id} | Team: {item.Name}");
     }
 }
-
-
 
 ////async Task ExecuteNonQueryCommand()
 ////{
@@ -196,7 +189,6 @@ async Task TeamsHistoryTemporalQueries()
 ////        .Include(q => q.Coach)
 ////        .ToListAsync();
 ////}
-
 
 ////async Task TrackingVsNoTracking()
 ////{


### PR DESCRIPTION
1. VS raises warnings to the GH code as-is, and this distracts/distrusts the dev reader
2. VS latest release (v6 LTS Nov21) introduces C# language enhancements [file-scoped ns, top-level progs etc]
3. previous V5 release is now unsupported, so devs should adopt latest v6.x era, including modern C# lang idioms

this PR modernises author's GH original (to eliminate warnings and take advantage of latest C# syntax) and adds .editorconfig as encouragement for author/other devs to standardise [imho should be in every repo!]

the Migrations folder kept as-was deliberately (i.e. my changes reverted there) as this is EF tool-generated code
- does mean a few VS warnings remain but this just shows prevailing foibles devs can expect

Hopefully author (and Packt) endorse the "..distractions .." wisdom in author's readme.md and accept & adopt this PR into official repo to benefit future passing pilgrims. "Soli Deo gloria" (glory to God alone)!